### PR TITLE
feat(infra): add terraform resources for serverless backend

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -11,3 +11,9 @@ variable "domain_name" {
   type        = string
   default     = "cmserverptf.click"
 }
+
+variable "website_url" {
+  description = "The full HTTPS URL of the portfolio website."
+  type        = string
+  default     = "https://www.cmserverptf.click"
+}


### PR DESCRIPTION
### Key Infrastructure Components Added

-   **DynamoDB Table (`aws_dynamodb_table`):**
    -   Creates a new table to store the visitor count.
    -   Configured with `PAY_PER_REQUEST` billing mode for maximum cost-effectiveness, aligning with serverless best practices.
    -   Includes a `local-exec` provisioner to initialize the counter item at creation time.

-   **IAM Role for Lambda (`aws_iam_role`):**
    -   Creates a dedicated execution role for the Lambda function.
    -   Follows the **Principle of Least Privilege** by attaching a custom policy that only grants the specific permissions needed:
        -   `dynamodb:UpdateItem` and `dynamodb:GetItem` on the specific counter table.
        -   Permissions to write logs to CloudWatch.

-   **Lambda Function (`aws_lambda_function`):**
    -   Uses the `archive_file` data source to automatically package the Python source code from the `functions/visitor-counter` directory into a zip file for deployment.
    -   Deploys the Python 3.10 function, linking it to the IAM role.
    -   Securely passes the DynamoDB table name and primary key to the function via environment variables.

-   **API Gateway (`aws_apigatewayv2_api`):**
    -   Creates a public HTTP API to act as the trigger for the Lambda function.
    -   Configured with a **secure CORS policy** that explicitly allows requests only from the `www.cmserverptf.click` domain, preventing unauthorized use.
    -   Defines the `GET /` route and integrates it with the Lambda function.

-   **Outputs:**
    -   Adds a new Terraform output, `api_endpoint_url`, to easily retrieve the invoke URL of the newly deployed API.