### PR TITLE
fix(auth): Grant ECS Task Role Permissions to DynamoDB

### DIFF
--- a/modules/ecs-fargate-service/main.tf
+++ b/modules/ecs-fargate-service/main.tf
@@ -1,3 +1,6 @@
+
+data "aws_caller_identity" "current" {}
+
 # Fetch the default VPC and subnets for our account
 data "aws_vpc" "default" {
   default = true
@@ -118,6 +121,7 @@ resource "aws_ecs_task_definition" "app" {
   cpu                      = "256"  # 0.25 vCPU
   memory                   = "512"  # 512 MB
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn  
 
   container_definitions = jsonencode([{
     name      = "visitor-counter-container"
@@ -158,4 +162,35 @@ resource "aws_ecs_service" "main" {
 
   # This ensures the service waits for the load balancer to be ready.
   depends_on = [aws_lb_listener.http]
+}
+
+# IAM: Role for the Application inside the container
+resource "aws_iam_role" "ecs_task_role" {
+  name = "ecs-task-role"
+  assume_role_policy = jsonencode({
+    Version   = "2012-10-17",
+    Statement = [{
+      Action    = "sts:AssumeRole",
+      Effect    = "Allow",
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "ecs_task_dynamodb_policy" {
+  name = "ecs-task-dynamodb-policy"
+  role = aws_iam_role.ecs_task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["dynamodb:UpdateItem", "dynamodb:GetItem"]
+        Effect   = "Allow"
+        Resource = "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/visitor-counter-table"
+      }
+    ]
+  })
 }


### PR DESCRIPTION
### Summary

This PR resolves a runtime permissions error in the containerized backend. The ECS service was successfully deployed, but the application code inside the container was receiving an error because it lacked the necessary IAM permissions to communicate with the DynamoDB table.

This change introduces a dedicated **ECS Task Role** to grant these permissions, following the principle of least privilege.


-   **IAM Task Role (`aws_iam_role`):**
    -   Creates a new IAM role, `ecs-task-role`, which is distinct from the Task *Execution* Role. 
        -   **Execution Role:** Permissions for the ECS service to manage infrastructure (e.g., pull ECR images).
        -   **Task Role:** Permissions for the application code running *inside* the container.

-   **Least-Privilege Policy (`aws_iam_role_policy`):**
    -   Attaches a specific, narrowly-scoped policy to the new Task Role.
    -   The policy grants only `dynamodb:UpdateItem` and `dynamodb:GetItem` permissions, and only on the specific `visitor-counter-table` resource.

-   **ECS Task Definition Update:**
    -   Updates the `aws_ecs_task_definition` to associate the new `task_role_arn`. This injects the permissions into the running container.
