### PR TITLE
fix(networking): Make ALB Public for CloudFront Origin Resolution

### DIFF
--- a/modules/ecs-fargate-service/main.tf
+++ b/modules/ecs-fargate-service/main.tf
@@ -119,7 +119,7 @@ resource "aws_security_group" "ecs_sg" {
 # 5. Networking: Load Balancer
 resource "aws_lb" "app" {
   name               = "portfolio-app-lb"
-  internal           = true # <-- THE KEY CHANGE: MAKE THE ALB INTERNAL
+  internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.lb_sg.id]
   subnets            = data.aws_subnets.default.ids


### PR DESCRIPTION
### Summary

This PR fixes a "502 Bad Gateway" error that occurred when trying to access the containerized API via CloudFront. The root cause was a network resolution issue: the Application Load Balancer (ALB) was configured as `internal`, making its DNS name unresolvable from the public internet where CloudFront operates.

### Key Changes & Skills Demonstrated

-   **Problem Diagnosis:**
    -   Diagnosed a 502 error by understanding that CloudFront, as a global service, could not resolve the private DNS of an internal ALB within the VPC.

-   **Architectural Correction:**
    -   Modified the `aws_lb` resource in the `ecs-fargate-service` module, changing the `internal` flag from `true` to `false`.
    -   This change makes the ALB's DNS name publicly resolvable, allowing CloudFront to successfully connect to it as an origin.

-   **Security Posture Maintained:**
    -   This change **does not compromise security**. The ALB's security group (`portfolio-lb-sg`) is still in place and is configured with an inbound rule that **only allows traffic from the official AWS CloudFront managed prefix list**. All other direct traffic to the ALB will be dropped by the firewall.